### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(DRRGenerator)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerDRRGenerator")
+set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerDRRGenerator#readme")
 set(EXTENSION_CATEGORY "Filtering")
 set(EXTENSION_CONTRIBUTORS "Lance Levine")
 set(EXTENSION_DESCRIPTION "This extension allows the user to generate DRRs via a highly customizable GUI")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lassoan/SlicerDRRGenerator/master/DRRGenerator.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/lassoan/SlicerDRRGenerator/master/DRRGenerator.png")
+set(EXTENSION_SCREENSHOTURLS "")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated string, a list or 'NA' if any
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.